### PR TITLE
Correct URI exception catching

### DIFF
--- a/WebContent/active-form-action-version/LFI-Detection-Evaluation-POST-200Error/inclusion-logic.jsp
+++ b/WebContent/active-form-action-version/LFI-Detection-Evaluation-POST-200Error/inclusion-logic.jsp
@@ -467,7 +467,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active-form-action-version/LFI-Detection-Evaluation-POST-200Identical/inclusion-logic.jsp
+++ b/WebContent/active-form-action-version/LFI-Detection-Evaluation-POST-200Identical/inclusion-logic.jsp
@@ -467,7 +467,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active-form-action-version/LFI-Detection-Evaluation-POST-200Valid/inclusion-logic.jsp
+++ b/WebContent/active-form-action-version/LFI-Detection-Evaluation-POST-200Valid/inclusion-logic.jsp
@@ -467,7 +467,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active-form-action-version/LFI-Detection-Evaluation-POST-302Redirect/inclusion-logic.jsp
+++ b/WebContent/active-form-action-version/LFI-Detection-Evaluation-POST-302Redirect/inclusion-logic.jsp
@@ -467,7 +467,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active-form-action-version/LFI-Detection-Evaluation-POST-404Error/inclusion-logic.jsp
+++ b/WebContent/active-form-action-version/LFI-Detection-Evaluation-POST-404Error/inclusion-logic.jsp
@@ -467,7 +467,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active-form-action-version/LFI-Detection-Evaluation-POST-500Error/inclusion-logic.jsp
+++ b/WebContent/active-form-action-version/LFI-Detection-Evaluation-POST-500Error/inclusion-logic.jsp
@@ -467,7 +467,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active-form-action-version/RFI-Detection-Evaluation-POST-200Error/inclusion-logic.jsp
+++ b/WebContent/active-form-action-version/RFI-Detection-Evaluation-POST-200Error/inclusion-logic.jsp
@@ -471,7 +471,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active-form-action-version/RFI-Detection-Evaluation-POST-200Identical/inclusion-logic.jsp
+++ b/WebContent/active-form-action-version/RFI-Detection-Evaluation-POST-200Identical/inclusion-logic.jsp
@@ -471,7 +471,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active-form-action-version/RFI-Detection-Evaluation-POST-200Valid/inclusion-logic.jsp
+++ b/WebContent/active-form-action-version/RFI-Detection-Evaluation-POST-200Valid/inclusion-logic.jsp
@@ -471,7 +471,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active-form-action-version/RFI-Detection-Evaluation-POST-302Redirect/inclusion-logic.jsp
+++ b/WebContent/active-form-action-version/RFI-Detection-Evaluation-POST-302Redirect/inclusion-logic.jsp
@@ -471,7 +471,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active-form-action-version/RFI-Detection-Evaluation-POST-404Error/inclusion-logic.jsp
+++ b/WebContent/active-form-action-version/RFI-Detection-Evaluation-POST-404Error/inclusion-logic.jsp
@@ -471,7 +471,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active-form-action-version/RFI-Detection-Evaluation-POST-500Error/inclusion-logic.jsp
+++ b/WebContent/active-form-action-version/RFI-Detection-Evaluation-POST-500Error/inclusion-logic.jsp
@@ -471,7 +471,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active/LFI/LFI-Detection-Evaluation-GET-200Error/inclusion-logic.jsp
+++ b/WebContent/active/LFI/LFI-Detection-Evaluation-GET-200Error/inclusion-logic.jsp
@@ -464,7 +464,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active/LFI/LFI-Detection-Evaluation-GET-200Identical/inclusion-logic.jsp
+++ b/WebContent/active/LFI/LFI-Detection-Evaluation-GET-200Identical/inclusion-logic.jsp
@@ -464,7 +464,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active/LFI/LFI-Detection-Evaluation-GET-200Valid/inclusion-logic.jsp
+++ b/WebContent/active/LFI/LFI-Detection-Evaluation-GET-200Valid/inclusion-logic.jsp
@@ -464,7 +464,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active/LFI/LFI-Detection-Evaluation-GET-302Redirect/inclusion-logic.jsp
+++ b/WebContent/active/LFI/LFI-Detection-Evaluation-GET-302Redirect/inclusion-logic.jsp
@@ -464,7 +464,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active/LFI/LFI-Detection-Evaluation-GET-404Error/inclusion-logic.jsp
+++ b/WebContent/active/LFI/LFI-Detection-Evaluation-GET-404Error/inclusion-logic.jsp
@@ -464,7 +464,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active/LFI/LFI-Detection-Evaluation-GET-500Error/inclusion-logic.jsp
+++ b/WebContent/active/LFI/LFI-Detection-Evaluation-GET-500Error/inclusion-logic.jsp
@@ -464,7 +464,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active/LFI/LFI-Detection-Evaluation-POST-200Error/inclusion-logic.jsp
+++ b/WebContent/active/LFI/LFI-Detection-Evaluation-POST-200Error/inclusion-logic.jsp
@@ -464,7 +464,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active/LFI/LFI-Detection-Evaluation-POST-200Identical/inclusion-logic.jsp
+++ b/WebContent/active/LFI/LFI-Detection-Evaluation-POST-200Identical/inclusion-logic.jsp
@@ -464,7 +464,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active/LFI/LFI-Detection-Evaluation-POST-200Valid/inclusion-logic.jsp
+++ b/WebContent/active/LFI/LFI-Detection-Evaluation-POST-200Valid/inclusion-logic.jsp
@@ -464,7 +464,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active/LFI/LFI-Detection-Evaluation-POST-302Redirect/inclusion-logic.jsp
+++ b/WebContent/active/LFI/LFI-Detection-Evaluation-POST-302Redirect/inclusion-logic.jsp
@@ -464,7 +464,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active/LFI/LFI-Detection-Evaluation-POST-404Error/inclusion-logic.jsp
+++ b/WebContent/active/LFI/LFI-Detection-Evaluation-POST-404Error/inclusion-logic.jsp
@@ -464,7 +464,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active/LFI/LFI-Detection-Evaluation-POST-500Error/inclusion-logic.jsp
+++ b/WebContent/active/LFI/LFI-Detection-Evaluation-POST-500Error/inclusion-logic.jsp
@@ -464,7 +464,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active/LFI/LFI-FalsePositives-GET/inclusion-logic.jsp
+++ b/WebContent/active/LFI/LFI-FalsePositives-GET/inclusion-logic.jsp
@@ -489,7 +489,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active/RFI/RFI-Detection-Evaluation-GET-200Error/inclusion-logic.jsp
+++ b/WebContent/active/RFI/RFI-Detection-Evaluation-GET-200Error/inclusion-logic.jsp
@@ -468,7 +468,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active/RFI/RFI-Detection-Evaluation-GET-200Identical/inclusion-logic.jsp
+++ b/WebContent/active/RFI/RFI-Detection-Evaluation-GET-200Identical/inclusion-logic.jsp
@@ -468,7 +468,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active/RFI/RFI-Detection-Evaluation-GET-200Valid/inclusion-logic.jsp
+++ b/WebContent/active/RFI/RFI-Detection-Evaluation-GET-200Valid/inclusion-logic.jsp
@@ -468,7 +468,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active/RFI/RFI-Detection-Evaluation-GET-302Redirect/inclusion-logic.jsp
+++ b/WebContent/active/RFI/RFI-Detection-Evaluation-GET-302Redirect/inclusion-logic.jsp
@@ -468,7 +468,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active/RFI/RFI-Detection-Evaluation-GET-404Error/inclusion-logic.jsp
+++ b/WebContent/active/RFI/RFI-Detection-Evaluation-GET-404Error/inclusion-logic.jsp
@@ -468,7 +468,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active/RFI/RFI-Detection-Evaluation-GET-500Error/inclusion-logic.jsp
+++ b/WebContent/active/RFI/RFI-Detection-Evaluation-GET-500Error/inclusion-logic.jsp
@@ -468,7 +468,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active/RFI/RFI-Detection-Evaluation-POST-200Error/inclusion-logic.jsp
+++ b/WebContent/active/RFI/RFI-Detection-Evaluation-POST-200Error/inclusion-logic.jsp
@@ -468,7 +468,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active/RFI/RFI-Detection-Evaluation-POST-200Identical/inclusion-logic.jsp
+++ b/WebContent/active/RFI/RFI-Detection-Evaluation-POST-200Identical/inclusion-logic.jsp
@@ -468,7 +468,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active/RFI/RFI-Detection-Evaluation-POST-200Valid/inclusion-logic.jsp
+++ b/WebContent/active/RFI/RFI-Detection-Evaluation-POST-200Valid/inclusion-logic.jsp
@@ -468,7 +468,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active/RFI/RFI-Detection-Evaluation-POST-302Redirect/inclusion-logic.jsp
+++ b/WebContent/active/RFI/RFI-Detection-Evaluation-POST-302Redirect/inclusion-logic.jsp
@@ -468,7 +468,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active/RFI/RFI-Detection-Evaluation-POST-404Error/inclusion-logic.jsp
+++ b/WebContent/active/RFI/RFI-Detection-Evaluation-POST-404Error/inclusion-logic.jsp
@@ -468,7 +468,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active/RFI/RFI-Detection-Evaluation-POST-500Error/inclusion-logic.jsp
+++ b/WebContent/active/RFI/RFI-Detection-Evaluation-POST-500Error/inclusion-logic.jsp
@@ -468,7 +468,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active/RFI/RFI-FalsePositives-GET/inclusion-logic.jsp
+++ b/WebContent/active/RFI/RFI-FalsePositives-GET/inclusion-logic.jsp
@@ -493,7 +493,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);

--- a/WebContent/active/Unvalidated-Redirect/Redirect-FalsePositives-GET/inclusion-logic.jsp
+++ b/WebContent/active/Unvalidated-Redirect/Redirect-FalsePositives-GET/inclusion-logic.jsp
@@ -493,7 +493,7 @@
 						URL url = new URL(targetFile);
 						try {
 							file = new File(url.toURI());
-						} catch (URISyntaxException e) {
+						} catch (Exception e) {
 							file = new File(url.getPath());
 						}
 						is = new FileInputStream(file);


### PR DESCRIPTION
The examples were failing with `Exception details: java.lang.IllegalArgumentException: URI has an authority component`.