### PR TITLE
Remove OWASP association from ZAP/Zed Attack Proxy references

### DIFF
--- a/WebContent/active/Reflected-XSS/RXSS-Detection-Evaluation-COOKIE-Experimental/Case01-Tag2HtmlPageScope.jsp
+++ b/WebContent/active/Reflected-XSS/RXSS-Detection-Evaluation-COOKIE-Experimental/Case01-Tag2HtmlPageScope.jsp
@@ -10,8 +10,8 @@
 <body>
 
 <!--
-    Inspired by a vulnerable test case originally written for the OWASP Zed Attack Proxy (ZAP) project
-    (http://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project) 
+    Inspired by a vulnerable test case originally written for the Zed Attack Proxy (ZAP) project
+    (https://www.zaproxy.org) 
     Original Author: psiinon (psiinon@gmail.com).
 -->
 

--- a/WebContent/active/Reflected-XSS/RXSS-Detection-Evaluation-GET-Experimental/Case01-Tag2HtmlPageScope-StripScriptTag.jsp
+++ b/WebContent/active/Reflected-XSS/RXSS-Detection-Evaluation-GET-Experimental/Case01-Tag2HtmlPageScope-StripScriptTag.jsp
@@ -9,8 +9,8 @@
 <body>
 
 <!--
-    Inspired by a vulnerable test case originally written for the OWASP Zed Attack Proxy (ZAP) project
-    (http://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project) 
+    Inspired by a vulnerable test case originally written for the Zed Attack Proxy (ZAP) project
+    (https://www.zaproxy.org) 
     Original Author: psiinon (psiinon@gmail.com).
 -->
 

--- a/WebContent/active/Reflected-XSS/RXSS-Detection-Evaluation-GET-Experimental/Case02-Tag2HtmlPageScope-SecretVectorPOST.jsp
+++ b/WebContent/active/Reflected-XSS/RXSS-Detection-Evaluation-GET-Experimental/Case02-Tag2HtmlPageScope-SecretVectorPOST.jsp
@@ -9,8 +9,8 @@
 <body>
 
 <!--
-    Inspired by a vulnerable test case originally written for the OWASP Zed Attack Proxy (ZAP) project
-    (http://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project) 
+    Inspired by a vulnerable test case originally written for the Zed Attack Proxy (ZAP) project
+    (https://www.zaproxy.org) 
     Original Author: psiinon (psiinon@gmail.com).
 -->
 

--- a/WebContent/active/Reflected-XSS/RXSS-Detection-Evaluation-GET-Experimental/Case03-Tag2HtmlPageScope-ConstantAntiCSRFToken.jsp
+++ b/WebContent/active/Reflected-XSS/RXSS-Detection-Evaluation-GET-Experimental/Case03-Tag2HtmlPageScope-ConstantAntiCSRFToken.jsp
@@ -9,8 +9,8 @@
 <body>
 
 <!--
-    Inspired by a vulnerable test case originally written for the OWASP Zed Attack Proxy (ZAP) project
-    (http://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project) 
+    Inspired by a vulnerable test case originally written for the Zed Attack Proxy (ZAP) project
+    (https://www.zaproxy.org) 
     Original Author: psiinon (psiinon@gmail.com).
 -->
 

--- a/WebContent/active/Reflected-XSS/RXSS-Detection-Evaluation-GET-Experimental/Case04-Tag2HtmlPageScope-ChangingAntiCSRFToken.jsp
+++ b/WebContent/active/Reflected-XSS/RXSS-Detection-Evaluation-GET-Experimental/Case04-Tag2HtmlPageScope-ChangingAntiCSRFToken.jsp
@@ -9,8 +9,8 @@
 <body>
 
 <!--
-    Inspired by a vulnerable test case originally written for the OWASP Zed Attack Proxy (ZAP) project
-    (http://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project) 
+    Inspired by a vulnerable test case originally written for the Zed Attack Proxy (ZAP) project
+    (https://www.zaproxy.org) 
     Original Author: psiinon (psiinon@gmail.com).
 -->
 

--- a/WebContent/active/Reflected-XSS/RXSS-Detection-Evaluation-GET-Experimental/index.jsp
+++ b/WebContent/active/Reflected-XSS/RXSS-Detection-Evaluation-GET-Experimental/index.jsp
@@ -20,7 +20,7 @@
 <font size="5">Test Cases:</font><br><br>
 <B><a href="Case01-Tag2HtmlPageScope-StripScriptTag.jsp?userinput=textvalue">Case01-Tag2HtmlPageScope-StripScriptTag.jsp</a></B><br>
   Injection of tags to the scope of the HTML page that strips script tags.<br>
-  (Contributed by the <b>OWASP Zed Attack Proxy (ZAP) project</b>, via Simon Bennetts)<br>
+  (Contributed by the <b>Zed Attack Proxy (ZAP) project</b>, via Simon Bennetts)<br>
   <U>Barriers:</U><br>
   Script tags are stripped from the input<br>
   <U>Sample Exploit Structures:</U><br>
@@ -33,7 +33,7 @@
   
 <B><a href="Case02-Tag2HtmlPageScope-SecretVectorPOST.jsp?userinput=textvalue">Case02-Tag2HtmlPageScope-SecretVectorPOST.jsp</a></B><br>
   Injection of tags to the scope of the HTML page that that only relies on secret POST input.<br>
-  (Contributed by the <b>OWASP Zed Attack Proxy (ZAP) project</b>, via Simon Bennetts)<br>
+  (Contributed by the <b>Zed Attack Proxy (ZAP) project</b>, via Simon Bennetts)<br>
   <U>Barriers:</U><br>
   Secret input vector without any hints<br>
   <U>Sample Exploit Structures:</U><br>
@@ -48,7 +48,7 @@
   
 <B><a href="Case03-Tag2HtmlPageScope-ConstantAntiCSRFToken.jsp?anticsrf=<%=anticsrf%>&userinput=textvalue">Case03-Tag2HtmlPageScope-ConstantAntiCSRFToken.jsp</a></B><br>
   Injection of tags to the scope of the HTML page that requires a constant session stored AntiCSRF token.<br>
-  (Contributed by the <b>OWASP Zed Attack Proxy (ZAP) project</b>, via Simon Bennetts)<br>
+  (Contributed by the <b>Zed Attack Proxy (ZAP) project</b>, via Simon Bennetts)<br>
   <U>Barriers:</U><br>
   Requires a constant session-specific AntiCSRF token<br>
   <U>Sample Exploit Structures (alongside the AntiCSRF token):</U><br>
@@ -63,7 +63,7 @@
   
 <B><a href="Case04-Tag2HtmlPageScope-ChangingAntiCSRFToken.jsp">Case04-Tag2HtmlPageScope-ChangingAntiCSRFToken.jsp</a></B><br>
   Injection of tags to the scope of the HTML page that requires an expiring one-use session stored AntiCSRF token.<br>
-  (Contributed by the <b>OWASP Zed Attack Proxy (ZAP) project</b>, via Simon Bennetts)<br>
+  (Contributed by the <b>Zed Attack Proxy (ZAP) project</b>, via Simon Bennetts)<br>
   <U>Barriers:</U><br>
   Requires a changing, newly generated session-specific AntiCSRF token<br>
   <U>Sample Exploit Structures (alongside the AntiCSRF token):</U><br>

--- a/WebContent/active/Reflected-XSS/RXSS-Detection-Evaluation-POST-Experimental/Case01-Tag2HtmlPageScope-StripScriptTag.jsp
+++ b/WebContent/active/Reflected-XSS/RXSS-Detection-Evaluation-POST-Experimental/Case01-Tag2HtmlPageScope-StripScriptTag.jsp
@@ -9,8 +9,8 @@
 <body>
 
 <!--
-    Inspired by a vulnerable test case originally written for the OWASP Zed Attack Proxy (ZAP) project
-    (http://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project) 
+    Inspired by a vulnerable test case originally written for the Zed Attack Proxy (ZAP) project
+    (https://www.zaproxy.org) 
     Original Author: psiinon (psiinon@gmail.com).
 -->
 

--- a/WebContent/active/Reflected-XSS/RXSS-Detection-Evaluation-POST-Experimental/Case02-Tag2HtmlPageScope-SecretVectorGET.jsp
+++ b/WebContent/active/Reflected-XSS/RXSS-Detection-Evaluation-POST-Experimental/Case02-Tag2HtmlPageScope-SecretVectorGET.jsp
@@ -9,8 +9,8 @@
 <body>
 
 <!--
-    Inspired by a vulnerable test case originally written for the OWASP Zed Attack Proxy (ZAP) project
-    (http://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project) 
+    Inspired by a vulnerable test case originally written for the Zed Attack Proxy (ZAP) project
+    (https://www.zaproxy.org) 
     Original Author: psiinon (psiinon@gmail.com).
 -->
 

--- a/WebContent/active/Reflected-XSS/RXSS-Detection-Evaluation-POST-Experimental/Case03-Tag2HtmlPageScope-ConstantAntiCSRFToken.jsp
+++ b/WebContent/active/Reflected-XSS/RXSS-Detection-Evaluation-POST-Experimental/Case03-Tag2HtmlPageScope-ConstantAntiCSRFToken.jsp
@@ -9,8 +9,8 @@
 <body>
 
 <!--
-    Inspired by a vulnerable test case originally written for the OWASP Zed Attack Proxy (ZAP) project
-    (http://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project) 
+    Inspired by a vulnerable test case originally written for the Zed Attack Proxy (ZAP) project
+    (https://www.zaproxy.org) 
     Original Author: psiinon (psiinon@gmail.com).
 -->
 

--- a/WebContent/active/Reflected-XSS/RXSS-Detection-Evaluation-POST-Experimental/Case04-Tag2HtmlPageScope-ChangingAntiCSRFToken.jsp
+++ b/WebContent/active/Reflected-XSS/RXSS-Detection-Evaluation-POST-Experimental/Case04-Tag2HtmlPageScope-ChangingAntiCSRFToken.jsp
@@ -9,8 +9,8 @@
 <body>
 
 <!--
-    Inspired by a vulnerable test case originally written for the OWASP Zed Attack Proxy (ZAP) project
-    (http://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project) 
+    Inspired by a vulnerable test case originally written for the Zed Attack Proxy (ZAP) project
+    (https://www.zaproxy.org) 
     Original Author: psiinon (psiinon@gmail.com).
 -->
 

--- a/WebContent/active/Reflected-XSS/RXSS-Detection-Evaluation-POST-Experimental/index.jsp
+++ b/WebContent/active/Reflected-XSS/RXSS-Detection-Evaluation-POST-Experimental/index.jsp
@@ -20,7 +20,7 @@
 <font size="5">Test Cases:</font><br><br>
 <B><a href="Case01-Tag2HtmlPageScope-StripScriptTag.jsp">Case01-Tag2HtmlPageScope-StripScriptTag.jsp</a></B><br>
   Injection of tags to the scope of the HTML page that strips script tags.<br>
-  (Contributed by the <b>OWASP Zed Attack Proxy (ZAP) project</b>, via Simon Bennetts)<br>
+  (Contributed by the <b>Zed Attack Proxy (ZAP) project</b>, via Simon Bennetts)<br>
   <U>Barriers:</U><br>
   Script tags are stripped from the input<br>
   <U>Sample Exploit Structures:</U><br>
@@ -33,7 +33,7 @@
   
 <B><a href="Case02-Tag2HtmlPageScope-SecretVectorGET.jsp">Case02-Tag2HtmlPageScope-SecretVectorGET.jsp</a></B><br>
   Injection of tags to the scope of the HTML page that that only relies on secret GET input.<br>
-  (Contributed by the <b>OWASP Zed Attack Proxy (ZAP) project</b>, via Simon Bennetts)<br>
+  (Contributed by the <b>Zed Attack Proxy (ZAP) project</b>, via Simon Bennetts)<br>
   <U>Barriers:</U><br>
   Secret input vector without any hints<br>
   <U>Sample Exploit Structures:</U><br>
@@ -48,7 +48,7 @@
   
 <B><a href="Case03-Tag2HtmlPageScope-ConstantAntiCSRFToken.jsp">Case03-Tag2HtmlPageScope-ConstantAntiCSRFToken.jsp</a></B><br>
   Injection of tags to the scope of the HTML page that requires a constant session stored AntiCSRF token.<br>
-  (Contributed by the <b>OWASP Zed Attack Proxy (ZAP) project</b>, via Simon Bennetts)<br>
+  (Contributed by the <b>Zed Attack Proxy (ZAP) project</b>, via Simon Bennetts)<br>
   <U>Barriers:</U><br>
   Requires a constant session-specific AntiCSRF token<br>
   <U>Sample Exploit Structures (alongside the AntiCSRF token):</U><br>
@@ -63,7 +63,7 @@
   
 <B><a href="Case04-Tag2HtmlPageScope-ChangingAntiCSRFToken.jsp">Case04-Tag2HtmlPageScope-ChangingAntiCSRFToken.jsp</a></B><br>
   Injection of tags to the scope of the HTML page that requires an expiring one-use session stored AntiCSRF token.<br>
-  (Contributed by the <b>OWASP Zed Attack Proxy (ZAP) project</b>, via Simon Bennetts)<br>
+  (Contributed by the <b>Zed Attack Proxy (ZAP) project</b>, via Simon Bennetts)<br>
   <U>Barriers:</U><br>
   Requires a changing, newly generated session-specific AntiCSRF token<br>
   <U>Sample Exploit Structures (alongside the AntiCSRF token):</U><br>

--- a/WebContent/active/SQL-Injection/SInjection-Detection-Evaluation-GET-200Error-Experimental/Case01-InjectionInInsertValues-String-BinaryDeliberateRuntimeError-With200Errors.jsp
+++ b/WebContent/active/SQL-Injection/SInjection-Detection-Evaluation-GET-200Error-Experimental/Case01-InjectionInInsertValues-String-BinaryDeliberateRuntimeError-With200Errors.jsp
@@ -12,8 +12,8 @@
 <body>
 
 <!--
-    Inspired by a vulnerable test case originally written for the OWASP Zed Attack Proxy (ZAP) project
-    (http://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project) 
+    Inspired by a vulnerable test case originally written for the Zed Attack Proxy (ZAP) project
+    (https://www.zaproxy.org) 
     Original Author: psiinon (psiinon@gmail.com).
 -->
 

--- a/WebContent/active/SQL-Injection/SInjection-Detection-Evaluation-POST-200Error-Experimental/Case01-InjectionInInsertValues-String-BinaryDeliberateRuntimeError-With200Errors.jsp
+++ b/WebContent/active/SQL-Injection/SInjection-Detection-Evaluation-POST-200Error-Experimental/Case01-InjectionInInsertValues-String-BinaryDeliberateRuntimeError-With200Errors.jsp
@@ -12,8 +12,8 @@
 <body>
 
 <!--
-    Inspired by a vulnerable test case originally written for the OWASP Zed Attack Proxy (ZAP) project
-    (http://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project) 
+    Inspired by a vulnerable test case originally written for the Zed Attack Proxy (ZAP) project
+    (https://www.zaproxy.org) 
     Original Author: psiinon (psiinon@gmail.com).
 -->
 

--- a/WebContent/passive/index-info.jsp
+++ b/WebContent/passive/index-info.jsp
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2//EN">
 <!--
-	Inspired by a vulnerable test case originally written for the OWASP Zed Attack Proxy (ZAP) project
-	(http://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project) 
+	Inspired by a vulnerable test case originally written for the Zed Attack Proxy (ZAP) project
+	(https://www.zaproxy.org) 
 	Original Author: psiinon (psiinon@gmail.com).
 -->
 <head>

--- a/WebContent/passive/index-session.jsp
+++ b/WebContent/passive/index-session.jsp
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2//EN">
 <!--
-	Inspired by a vulnerable test case originally written for the OWASP Zed Attack Proxy (ZAP) project
-	(http://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project) 
+	Inspired by a vulnerable test case originally written for the Zed Attack Proxy (ZAP) project
+	(https://www.zaproxy.org) 
 	Original Author: psiinon (psiinon@gmail.com).
 -->
 <head>

--- a/WebContent/passive/index.jsp
+++ b/WebContent/passive/index.jsp
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2//EN">
 <!--
-	Inspired by a vulnerable test case originally written for the OWASP Zed Attack Proxy (ZAP) project
-	(http://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project) 
+	Inspired by a vulnerable test case originally written for the Zed Attack Proxy (ZAP) project
+	(https://www.zaproxy.org) 
 	Original Author: psiinon (psiinon@gmail.com).
 -->
 <head>

--- a/WebContent/passive/info/index.jsp
+++ b/WebContent/passive/info/index.jsp
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2//EN">
 <!--
-	Inspired by a vulnerable test case originally written for the OWASP Zed Attack Proxy (ZAP) project
-	(http://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project) 
+	Inspired by a vulnerable test case originally written for the Zed Attack Proxy (ZAP) project
+	(https://www.zaproxy.org) 
 	Original Author: psiinon (psiinon@gmail.com).
 -->
 <head>
@@ -11,7 +11,7 @@
 
 <H2>Information Leakage</H2>
 <br>
-(Contributed by the <b>OWASP Zed Attack Proxy (ZAP) project</b>, via Simon Bennetts)<br>
+(Contributed by the <b>Zed Attack Proxy (ZAP) project</b>, via Simon Bennetts)<br>
 <br>
 <H3>Examples</H3>
 <UL>

--- a/WebContent/passive/info/info-app-stack-trace.jsp
+++ b/WebContent/passive/info/info-app-stack-trace.jsp
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2//EN">
 <!--
-	Inspired by a vulnerable test case originally written for the OWASP Zed Attack Proxy (ZAP) project
-	(http://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project) 
+	Inspired by a vulnerable test case originally written for the Zed Attack Proxy (ZAP) project
+	(https://www.zaproxy.org) 
 	Original Author: psiinon (psiinon@gmail.com).
 -->
 <%@ page import="java.util.*" %>

--- a/WebContent/passive/info/info-cookie-no-httponly.jsp
+++ b/WebContent/passive/info/info-cookie-no-httponly.jsp
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2//EN">
 <!--
-	Inspired by a vulnerable test case originally written for the OWASP Zed Attack Proxy (ZAP) project
-	(http://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project) 
+	Inspired by a vulnerable test case originally written for the Zed Attack Proxy (ZAP) project
+	(https://www.zaproxy.org) 
 	Original Author: psiinon (psiinon@gmail.com).
 -->
 <%@ page import="java.util.*" %>

--- a/WebContent/passive/info/info-server-stack-trace.jsp
+++ b/WebContent/passive/info/info-server-stack-trace.jsp
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2//EN">
 <!--
-	Inspired by a vulnerable test case originally written for the OWASP Zed Attack Proxy (ZAP) project
-	(http://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project) 
+	Inspired by a vulnerable test case originally written for the Zed Attack Proxy (ZAP) project
+	(https://www.zaproxy.org) 
 	Original Author: psiinon (psiinon@gmail.com).
 -->
 <%@ page import="java.util.*" %>

--- a/WebContent/passive/session/index.jsp
+++ b/WebContent/passive/session/index.jsp
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2//EN">
 <!--
-	Inspired by a vulnerable test case originally written for the OWASP Zed Attack Proxy (ZAP) project
-	(http://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project) 
+	Inspired by a vulnerable test case originally written for the Zed Attack Proxy (ZAP) project
+	(https://www.zaproxy.org) 
 	Original Author: psiinon (psiinon@gmail.com).
 -->
 <head>
@@ -11,7 +11,7 @@
 
 <H2>Session vulnerabilities</H2>
 <br>
-(Contributed by the <b>OWASP Zed Attack Proxy (ZAP) project</b>, via Simon Bennetts)<br>
+(Contributed by the <b>Zed Attack Proxy (ZAP) project</b>, via Simon Bennetts)<br>
 <br>
 <H3>Examples</H3>
 <UL>

--- a/WebContent/passive/session/session-password-autocomplete.jsp
+++ b/WebContent/passive/session/session-password-autocomplete.jsp
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2//EN">
 <!--
-	Inspired by a vulnerable test case originally written for the OWASP Zed Attack Proxy (ZAP) project
-	(http://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project) 
+	Inspired by a vulnerable test case originally written for the Zed Attack Proxy (ZAP) project
+	(https://www.zaproxy.org) 
 	Original Author: psiinon (psiinon@gmail.com).
 -->
 <head>

--- a/WebContent/passive/session/weak-authentication-basic.jsp
+++ b/WebContent/passive/session/weak-authentication-basic.jsp
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2//EN">
 <!--
-	Inspired by a vulnerable test case originally written for the OWASP Zed Attack Proxy (ZAP) project
-	(http://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project) 
+	Inspired by a vulnerable test case originally written for the Zed Attack Proxy (ZAP) project
+	(https://www.zaproxy.org) 
 	Original Author: psiinon (psiinon@gmail.com).
 -->
 <head>


### PR DESCRIPTION
ZAP left the OWASP foundation a few years ago. Update all mentions of 'OWASP Zed Attack Proxy (ZAP)' to 'Zed Attack Proxy (ZAP)' and replace the old OWASP wiki project URL with https://www.zaproxy.org.